### PR TITLE
[DEV-2628] Add reason as an additional argument to terminate-user-session

### DIFF
--- a/src/aging_session/modify_user_session.clj
+++ b/src/aging_session/modify_user_session.clj
@@ -14,5 +14,6 @@
    all existing user sessions."
 
   (terminate-user-sessions
-    [store keys]
-    "Accepts a session-store and multiple keys (session-ids) to terminate the user session(s)."))
+    [store keys reason]
+    "Accepts a session-store, multiple keys (session-ids) to terminate the user session(s) and a reason for why
+     the session was terminated."))


### PR DESCRIPTION
Provide a reason (`keyword`) when terminating a user's sessions