### PR TITLE
[DEV-4081] Freshly baked signed cookies!

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,23 @@ no way to get rid of sessions that are no longer being visited.
 Depending on how long running a server is and on how big its sessions are, 
 the unallocated sessions can potentially accumulate more and more memory.
 Another possible scenario is a denial of service attack where the attacker
-continually asks for new sessions thus exhusting the server of memory.
+continually asks for new sessions thus exhausting the server of memory.
 
 This session store has a sweeper thread that will apply a set of functions
 to every session object after every X requests are made. These functions
 are also applied to every session when it is read.
 
+## MAJOR CHANGES IN 0.5.0
+
+- Cookies are now issued as signed tokens. 
+- Read/Write session interface changed to accommodate new cookie style.
+- Cookies cannot stay valid for longer than 72hours, regardless of expiry policy
+
 ## Dependency
 
 To use aging-session, include the following dependency in your project.clj file.
 
-[![Clojars Project](http://clojars.org/kirasystems/aging-session/latest-version.svg)](http://clojars.org/kirasystems/aging-session)
+[![Clojars Project](https://clojars.org/kirasystems/aging-session/latest-version.svg)](https://clojars.org/kirasystems/aging-session)
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/aging-session "0.3.6-SNAPSHOT"
+(defproject kirasystems/aging-session "0.5.0-SNAPSHOT"
   :description "Memory based ring session with expiry and time based mutation."
   :url "https://github.com/diligenceengine/aging-session"
   :license {:name "Eclipse Public License"
@@ -9,7 +9,14 @@
                               :username :env
                               :password :env}]]
 
-  :dependencies [[ring/ring-core "1.7.1"]]
+  :dependencies [[ring/ring-core "1.7.1"]
+                 [buddy/buddy-auth "2.2.0"]
+                 [buddy/buddy-core "1.6.0"]
+                 [buddy/buddy-sign "3.1.0"]
+                 [buddy/buddy-hashers "1.4.0"]
+                 [commons-codec "1.13"]
+                 [com.taoensso/nippy "2.14.0"]
+                 [org.clojure/tools.logging "0.5.0"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}}
 
   :release-tasks [["vcs" "assert-committed"]

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
                  [buddy/buddy-core "1.6.0"]
                  [buddy/buddy-sign "3.1.0"]
                  [buddy/buddy-hashers "1.4.0"]
+                 [clj-time "0.15.2"]
                  [commons-codec "1.13"]
                  [com.taoensso/nippy "2.14.0"]
                  [org.clojure/tools.logging "0.5.0"]]

--- a/src/aging_session/cookie.clj
+++ b/src/aging_session/cookie.clj
@@ -95,6 +95,6 @@
         [enc-key mac-key] (get-crypto-keys)
         cookie (some->> hmac
                         (verify-and-return-data iv enc-cookie mac-key)
-                        (#(decrypt (base64-decode iv) (base64-decode %) enc-key))
-                        not-expired?)]
-    cookie))
+                        (#(decrypt (base64-decode iv) (base64-decode %) enc-key)))]
+    (when (not-expired? cookie)
+      cookie)))

--- a/src/aging_session/cookie.clj
+++ b/src/aging_session/cookie.clj
@@ -1,4 +1,4 @@
-(ns aging-session.crypto
+(ns aging-session.cookie
   (:require [buddy.core.crypto :as crypto]
             [buddy.core.mac :as mac]
             [buddy.core.nonce :as nonce]

--- a/src/aging_session/cookie.clj
+++ b/src/aging_session/cookie.clj
@@ -28,7 +28,7 @@
 
 (defn next-session!
   []
-  (swap! internals-atom update-in [:counter] inc))
+  (:counter (swap! internals-atom update-in [:counter] inc)))
 
 (defn get-crypto-keys
   []
@@ -60,7 +60,7 @@
       (log/error "Error decrypting cookie: " e)
       nil)))
 
-(defn encrypt-and-hmac-cookie
+(defn bake-cookie
   [session-id]
   (let [[enc-key mac-key] (get-crypto-keys)
         iat (time/now)
@@ -86,7 +86,7 @@
                   iat)
     false))
 
-(defn verify-and-decrypt-cookie
+(defn get-id
   [url-cookie]
   (let [[iv enc-cookie hmac] (some-> url-cookie
                                      url-decode
@@ -97,4 +97,4 @@
                         (verify-and-return-data iv enc-cookie mac-key)
                         (#(decrypt (base64-decode iv) (base64-decode %) enc-key)))]
     (when (not-expired? cookie)
-      cookie)))
+      (:id cookie))))

--- a/src/aging_session/crypto.clj
+++ b/src/aging_session/crypto.clj
@@ -1,0 +1,101 @@
+(ns aging-session.crypto
+  (:require [buddy.core.crypto :as crypto]
+            [buddy.core.mac :as mac]
+            [buddy.core.nonce :as nonce]
+            [clj-time.core :as time]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [taoensso.nippy :as nippy]
+            [ring.util.codec :refer [url-encode url-decode]])
+  (:import [org.apache.commons.codec.binary Base64]))
+
+;; Base64 helpers
+(defn- string->bytes
+  "Convert UTF-8 string to bytes."
+  ^bytes [^String s]
+  (.getBytes s "UTF-8"))
+
+(defn base64-encode [b]
+  (Base64/encodeBase64String b))
+
+(defn base64-decode
+  ^bytes [^String s]
+  (Base64/decodeBase64 (string->bytes s)))
+
+(def ^:private internals-atom (atom {:enc-key nil
+                                     :mac-key nil
+                                     :counter 0}))
+
+(defn next-session!
+  []
+  (swap! internals-atom update-in [:counter] inc))
+
+(defn get-crypto-keys
+  []
+  (let [{enc-key :enc-key
+         mac-key :mac-key} @internals-atom]
+    (if (and enc-key mac-key)                               ; if keys are initialized - use them
+      [enc-key mac-key]
+      (do                                                   ; otherwise generate new keys and attempt to set them
+        (swap! internals-atom update-in [:enc-key] #(if-not % (nonce/random-bytes 32) %))
+        (swap! internals-atom update-in [:mac-key] #(if-not % (nonce/random-bytes 128) %))
+        (get-crypto-keys)))))                               ; retrieve the keys again, as something else may have set them in the meantime
+
+(defn encrypt
+  [key data]
+  (let [iv (nonce/random-bytes 16)]
+    [iv (crypto/encrypt-cbc (crypto/block-cipher :aes :cbc) (nippy/freeze data) key iv)]))
+
+(defn decrypt
+  "Attempt decryption of a payload given the corresponding IV and an encryption key.
+
+  Arguments:
+    - iv   - initialization vector provided with the encrypted payload
+    - data - ciphertext
+    - key  - decryption key"
+  [iv data key]
+  (try
+    (nippy/thaw (crypto/decrypt-cbc (crypto/block-cipher :aes :cbc) data key iv))
+    (catch Exception e
+      (log/error "Error decrypting cookie: " e)
+      nil)))
+
+(defn encrypt-and-hmac-cookie
+  [session-id]
+  (let [[enc-key mac-key] (get-crypto-keys)
+        iat (time/now)
+        [iv enc-cookie] (encrypt enc-key {:id session-id :iat iat})
+        ivb64 (base64-encode iv)
+        enc-cookieb64 (base64-encode enc-cookie)
+        hmac (mac/hash (str ivb64 enc-cookieb64) {:key mac-key :alg :hmac+sha512})
+        hmacb64 (base64-encode hmac)]
+    (some-> (str ivb64 "." enc-cookieb64 "." hmacb64)
+            url-encode)))
+
+(defn- verify-and-return-data
+  [iv data hmac key]
+  (and hmac
+       (mac/verify (str iv data) (base64-decode hmac) {:key key :alg :hmac+sha512})
+       data))
+
+(defn- not-expired?
+  [{iat :iat}]
+  (if iat
+    (time/within? (time/interval (time/minus (time/now)
+                                             (time/days 3))
+                                 (time/now))
+                  iat)
+    false))
+
+(defn verify-and-decrypt-cookie
+  [url-cookie]
+  (let [[iv enc-cookie hmac] (some-> url-cookie
+                                     url-decode
+                                     (or "")
+                                     (string/split #"\." 3))
+        [enc-key mac-key] (get-crypto-keys)
+        enc-data (verify-and-return-data iv enc-cookie hmac mac-key)
+        cookie (when enc-data
+                 (decrypt (base64-decode iv) (base64-decode enc-data) enc-key))]
+    (when (not-expired? cookie)
+      cookie)))

--- a/src/aging_session/memory.clj
+++ b/src/aging_session/memory.clj
@@ -1,30 +1,10 @@
 (ns aging-session.memory
   "In-memory session storage with mortality."
-  (:require [ring.middleware.session.store :refer :all]
-            [ring.util.codec :refer [url-encode url-decode]]
-            [buddy.core.crypto :as crypto]
-            [buddy.core.mac :as mac]
-            [buddy.core.nonce :as nonce]
-            [clj-time.core :as time]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [taoensso.nippy :as nippy])
-  (:import  [org.apache.commons.codec.binary Base64]))
+  (:require [aging-session.crypto :as crypto]
+            [ring.middleware.session.store :refer :all]
+            [ring.util.codec :refer [url-encode url-decode]]))
 
 (defrecord SessionEntry [timestamp value])
-
-;; Base64 helpers
-(defn- string->bytes
-  "Convert UTF-8 string to bytes."
-  ^bytes [^String s]
-  (.getBytes s "UTF-8"))
-
-(defn base64-encode [b]
-  (Base64/encodeBase64String b))
-
-(defn base64-decode
-  ^bytes [^String s]
-  (Base64/decodeBase64 (string->bytes s)))
 
 (defn- now
   "Return the current time in milliseconds."
@@ -64,67 +44,6 @@
     (assoc session-map key entry)
     (dissoc session-map key)))
 
-(def ^:private internals-atom (atom {:enc-key nil
-                                     :mac-key nil
-                                     :counter 0}))
-
-(defn get-crypto-keys
-  []
-  (let [{enc-key :enc-key
-         mac-key :mac-key} @internals-atom]
-    (if (and enc-key mac-key)                               ; if keys are present - use them
-      [enc-key mac-key]
-      (do                                                   ; otherwise generate new keys and attempt to set them
-        (swap! internals-atom update-in [:enc-key] #(if-not % (nonce/random-bytes 32) %))
-        (swap! internals-atom update-in [:mac-key] #(if-not % (nonce/random-bytes 128) %))
-        (get-crypto-keys)))))                               ; retrieve the keys again, as something else may have set them in the meantime
-
-(defn decrypt
-  [iv key data]
-  (try
-    (nippy/thaw (crypto/decrypt-cbc (crypto/block-cipher :aes :cbc) data key iv))
-    (catch Exception e
-      (log/error "Error decrypting cookie: " e)
-      nil)))
-
-(defn encrypt
-  [key data]
-  (let [iv (nonce/random-bytes 16)]
-    [iv (crypto/encrypt-cbc (crypto/block-cipher :aes :cbc) (nippy/freeze data) key iv)]))
-
-(defn verify-and-decrypt-cookie
-  [url-cookie]
-  (let [cookie (some-> url-cookie
-                       url-decode)
-        [enc-key mac-key] (get-crypto-keys)
-        [iv enc-cookie hmac] (string/split (or cookie "") #"\." 3)
-        enc-cookie (and hmac
-                        (mac/verify (str iv enc-cookie) (base64-decode hmac) {:key mac-key :alg :hmac+sha512})
-                        enc-cookie)
-        cookie (and enc-cookie
-                    (decrypt (base64-decode iv) enc-key (base64-decode enc-cookie)))
-        iat (and cookie
-                 (:iat cookie))]
-    (when (and cookie iat
-               (time/within? (time/interval (time/minus (time/now)
-                                                        (time/days 3))
-                                            (time/now))
-                             iat))
-      cookie)))
-
-(defn encrypt-and-hmac-cookie
-  [session-id]
-  (let [[enc-key mac-key] (get-crypto-keys)
-        iat (time/now)
-        [iv enc-cookie] (encrypt enc-key {:id session-id :iat iat})
-        ivb64 (base64-encode iv)
-        enc-cookieb64 (base64-encode enc-cookie)
-        hmac (mac/hash (str ivb64 enc-cookieb64) {:key mac-key :alg :hmac+sha512})
-        hmacb64 (base64-encode hmac)]
-    (some-> (str ivb64 "." enc-cookieb64 "." hmacb64)
-            url-encode)))
-
-
 (defprotocol AgingStore
   (read-timestamp [store key]
                   "Read a session from the store and return its timestamp. If no key exists, returns nil."))
@@ -136,16 +55,16 @@
 
   SessionStore
   (read-session [_ cookie]
-    (let [key (:id (verify-and-decrypt-cookie cookie))]
+    (let [key (:id (crypto/verify-and-decrypt-cookie cookie))]
       (swap! session-map sweep-entry event-fns key)
       (when (and refresh-on-read (contains? @session-map key))
         (swap! session-map assoc-in [key :timestamp] (now)))
       (get-in @session-map [key :value] {})))
 
   (write-session [_ cookie {:keys [bump-session?] :as data}]
-    (let [decrypted-cookie (verify-and-decrypt-cookie cookie)
+    (let [decrypted-cookie (crypto/verify-and-decrypt-cookie cookie)
           key (or (:id decrypted-cookie)
-                  (:counter (swap! internals-atom update-in [:counter] inc)))
+                  (:counter (crypto/next-session!)))
           session (cond-> data
                     bump-session? (assoc :last-access (System/currentTimeMillis))
                     true (dissoc :bump-session?))]
@@ -155,7 +74,7 @@
         (swap! session-map write-entry key session))
       (if decrypted-cookie
         cookie
-        (encrypt-and-hmac-cookie key))))
+        (crypto/encrypt-and-hmac-cookie key))))
 
   (delete-session [_ key]
     (swap! session-map dissoc key)

--- a/src/aging_session/memory.clj
+++ b/src/aging_session/memory.clj
@@ -1,9 +1,30 @@
 (ns aging-session.memory
   "In-memory session storage with mortality."
-  (:require [ring.middleware.session.store :refer :all])
-  (:import java.util.UUID))
+  (:require [ring.middleware.session.store :refer :all]
+            [ring.util.codec :refer [url-encode url-decode]]
+            [buddy.core.crypto :as crypto]
+            [buddy.core.mac :as mac]
+            [buddy.core.nonce :as nonce]
+            [clj-time.core :as time]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [taoensso.nippy :as nippy])
+  (:import  [org.apache.commons.codec.binary Base64]))
 
 (defrecord SessionEntry [timestamp value])
+
+;; Base64 helpers
+(defn- string->bytes
+  "Convert UTF-8 string to bytes."
+  ^bytes [^String s]
+  (.getBytes s "UTF-8"))
+
+(defn base64-encode [b]
+  (Base64/encodeBase64String b))
+
+(defn base64-decode
+  ^bytes [^String s]
+  (Base64/decodeBase64 (string->bytes s)))
 
 (defn- now
   "Return the current time in milliseconds."
@@ -43,6 +64,67 @@
     (assoc session-map key entry)
     (dissoc session-map key)))
 
+(def ^:private internals-atom (atom {:enc-key nil
+                                     :mac-key nil
+                                     :counter 0}))
+
+(defn get-crypto-keys
+  []
+  (let [{enc-key :enc-key
+         mac-key :mac-key} @internals-atom]
+    (if (and enc-key mac-key)                               ; if keys are present - use them
+      [enc-key mac-key]
+      (do                                                   ; otherwise generate new keys and attempt to set them
+        (swap! internals-atom update-in [:enc-key] #(if-not % (nonce/random-bytes 32) %))
+        (swap! internals-atom update-in [:mac-key] #(if-not % (nonce/random-bytes 128) %))
+        (get-crypto-keys)))))                               ; retrieve the keys again, as something else may have set them in the meantime
+
+(defn decrypt
+  [iv key data]
+  (try
+    (nippy/thaw (crypto/decrypt-cbc (crypto/block-cipher :aes :cbc) data key iv))
+    (catch Exception e
+      (log/error "Error decrypting cookie: " e)
+      nil)))
+
+(defn encrypt
+  [key data]
+  (let [iv (nonce/random-bytes 16)]
+    [iv (crypto/encrypt-cbc (crypto/block-cipher :aes :cbc) (nippy/freeze data) key iv)]))
+
+(defn verify-and-decrypt-cookie
+  [url-cookie]
+  (let [cookie (some-> url-cookie
+                       url-decode)
+        [enc-key mac-key] (get-crypto-keys)
+        [iv enc-cookie hmac] (string/split (or cookie "") #"\." 3)
+        enc-cookie (and hmac
+                        (mac/verify (str iv enc-cookie) (base64-decode hmac) {:key mac-key :alg :hmac+sha512})
+                        enc-cookie)
+        cookie (and enc-cookie
+                    (decrypt (base64-decode iv) enc-key (base64-decode enc-cookie)))
+        iat (and cookie
+                 (:iat cookie))]
+    (when (and cookie iat
+               (time/within? (time/interval (time/minus (time/now)
+                                                        (time/days 3))
+                                            (time/now))
+                             iat))
+      cookie)))
+
+(defn encrypt-and-hmac-cookie
+  [session-id]
+  (let [[enc-key mac-key] (get-crypto-keys)
+        iat (time/now)
+        [iv enc-cookie] (encrypt enc-key {:id session-id :iat iat})
+        ivb64 (base64-encode iv)
+        enc-cookieb64 (base64-encode enc-cookie)
+        hmac (mac/hash (str ivb64 enc-cookieb64) {:key mac-key :alg :hmac+sha512})
+        hmacb64 (base64-encode hmac)]
+    (some-> (str ivb64 "." enc-cookieb64 "." hmacb64)
+            url-encode)))
+
+
 (defprotocol AgingStore
   (read-timestamp [store key]
                   "Read a session from the store and return its timestamp. If no key exists, returns nil."))
@@ -53,14 +135,17 @@
     (get-in @session-map [key :timestamp]))
 
   SessionStore
-  (read-session [_ key]
-    (swap! session-map sweep-entry event-fns key)
-    (when (and refresh-on-read (contains? @session-map key))
-      (swap! session-map assoc-in [key :timestamp] (now)))
-    (get-in @session-map [key :value] {}))
+  (read-session [_ cookie]
+    (let [key (:id (verify-and-decrypt-cookie cookie))]
+      (swap! session-map sweep-entry event-fns key)
+      (when (and refresh-on-read (contains? @session-map key))
+        (swap! session-map assoc-in [key :timestamp] (now)))
+      (get-in @session-map [key :value] {})))
 
-  (write-session [_ key {:keys [bump-session?] :as data}]
-    (let [key (or key (str (UUID/randomUUID)))
+  (write-session [_ cookie {:keys [bump-session?] :as data}]
+    (let [decrypted-cookie (verify-and-decrypt-cookie cookie)
+          key (or (:id decrypted-cookie)
+                  (:counter (swap! internals-atom update-in [:counter] inc)))
           session (cond-> data
                     bump-session? (assoc :last-access (System/currentTimeMillis))
                     true (dissoc :bump-session?))]
@@ -68,7 +153,9 @@
       (if refresh-on-write    ; Write key and and update timestamp.
         (swap! session-map assoc key (new-entry session))
         (swap! session-map write-entry key session))
-      key))
+      (if decrypted-cookie
+        cookie
+        (encrypt-and-hmac-cookie key))))
 
   (delete-session [_ key]
     (swap! session-map dissoc key)

--- a/test/aging_session/cookie_test.clj
+++ b/test/aging_session/cookie_test.clj
@@ -6,7 +6,7 @@
 (deftest crypto-basic-functionality
   (testing "can create keys"
     (is (= 2 (count (get-crypto-keys)))))
-  (testing "key creation/retrieval is atomic"             ; this isn't proof, just a best-effort check
+  (testing "key creation/retrieval is atomic"               ; this isn't proof, just a best-effort check
     (is (= 1 (count (into #{} (doall (pmap #(do %& (map base64-encode (get-crypto-keys)))
                                            (range 100))))))))
   (testing "encryption roundtrip"
@@ -14,6 +14,13 @@
           key (first (get-crypto-keys))
           [iv enc-data] (encrypt key data)]
       (is (= data (decrypt iv enc-data key)))))
-  (testing "cookie roundtrip"
-    (let [id 1234567]
-      (is (= id (get-id (bake-cookie id)))))))
+  (let [id 1234567
+        cookie (bake-cookie id)]
+    (testing "cookie roundtrip"
+      (is (= id (get-id cookie))))
+    (testing "Corrupt IV results in nil"
+      (is (nil? (get-id (str "badpre" (subs cookie 6))))))
+    (testing "Corrupt MAC results in nil"
+      (is (nil? (get-id (str (subs cookie 0 (- (count cookie) 6)) "badsuf")))))
+    (testing "Corrupt payload results in nil"
+      (is (nil? (get-id (str (subs cookie 0 40) "badpay" (subs cookie 46))))))))

--- a/test/aging_session/cookie_test.clj
+++ b/test/aging_session/cookie_test.clj
@@ -1,0 +1,19 @@
+(ns aging-session.cookie-test
+  (:require [clojure.test :refer :all]
+            [aging-session.cookie :refer :all]))
+
+
+(deftest crypto-basic-functionality
+  (testing "can create keys"
+    (is (= 2 (count (get-crypto-keys)))))
+  (testing "key creation/retrieval is atomic"             ; this isn't proof, just a best-effort check
+    (is (= 1 (count (into #{} (doall (pmap #(do %& (map base64-encode (get-crypto-keys)))
+                                           (range 100))))))))
+  (testing "encryption roundtrip"
+    (let [data {:some :data}
+          key (first (get-crypto-keys))
+          [iv enc-data] (encrypt key data)]
+      (is (= data (decrypt iv enc-data key)))))
+  (testing "cookie roundtrip"
+    (let [id 1234567]
+      (is (= id (get-id (bake-cookie id)))))))

--- a/test/aging_session/event_test.clj
+++ b/test/aging_session/event_test.clj
@@ -9,7 +9,7 @@
 (deftest session-expiry
   (testing "Test session expiry."
     (let [as (aging-memory-store :events [(event/expires-after 1)])
-          cookie (write-session as "invalid-key" {:a 1})
+          cookie (write-session as nil {:a 1})
           id (get-id cookie)]
       (. Thread (sleep 1500))
       (is (= (read-session as cookie) {})))))
@@ -20,22 +20,22 @@
                :events      [(event/expires-after 1)]
                :sweep-every 5
                :sweep-delay 1000)
-          cookie (write-session as "invalid-key" {:a 1})
+          cookie (write-session as nil {:a 1})
           id (get-id cookie)]
       (. Thread (sleep 1500))
       ; key should still exist, even though it's expired
       (is (not (nil? (read-timestamp as id))))
 
       ; key should exist for three more writes
-      (write-session as "other-key" {:foo 1})
+      (write-session as nil {:foo 1})
       (is (not (nil? (read-timestamp as id))))
-      (write-session as "other-key" {:foo 1})
+      (write-session as nil {:foo 1})
       (is (not (nil? (read-timestamp as id))))
-      (write-session as "other-key" {:foo 1})
+      (write-session as nil {:foo 1})
       (is (not (nil? (read-timestamp as id))))
 
       ; on the fifth write and after 30s, key should not exist
-      (write-session as "other-key" {:foo 1})
+      (write-session as nil {:foo 1})
       (. Thread (sleep 2000))
       (is (nil? (read-timestamp as id))))))
 

--- a/test/aging_session/event_test.clj
+++ b/test/aging_session/event_test.clj
@@ -10,7 +10,7 @@
   (testing "Test session expiry."
     (let [as (aging-memory-store :events [(event/expires-after 1)])
           cookie (write-session as "invalid-key" {:a 1})
-          id (:id (verify-and-decrypt-cookie cookie))]
+          id (get-id cookie)]
       (. Thread (sleep 1500))
       (is (= (read-session as cookie) {})))))
 
@@ -21,7 +21,7 @@
                :sweep-every 5
                :sweep-delay 1000)
           cookie (write-session as "invalid-key" {:a 1})
-          id (:id (verify-and-decrypt-cookie cookie))]
+          id (get-id cookie)]
       (. Thread (sleep 1500))
       ; key should still exist, even though it's expired
       (is (not (nil? (read-timestamp as id))))

--- a/test/aging_session/event_test.clj
+++ b/test/aging_session/event_test.clj
@@ -3,7 +3,8 @@
     [aging-session.event :as event]
     [clojure.test :refer :all]
     [ring.middleware.session.store :refer :all]
-    [aging-session.memory :refer :all]))
+    [aging-session.memory :refer :all]
+    [aging-session.crypto :refer :all]))
 
 (deftest session-expiry
   (testing "Test session expiry."

--- a/test/aging_session/event_test.clj
+++ b/test/aging_session/event_test.clj
@@ -4,7 +4,7 @@
     [clojure.test :refer :all]
     [ring.middleware.session.store :refer :all]
     [aging-session.memory :refer :all]
-    [aging-session.crypto :refer :all]))
+    [aging-session.cookie :refer :all]))
 
 (deftest session-expiry
   (testing "Test session expiry."

--- a/test/aging_session/event_test.clj
+++ b/test/aging_session/event_test.clj
@@ -7,34 +7,36 @@
 
 (deftest session-expiry
   (testing "Test session expiry."
-    (let [as (aging-memory-store :events [(event/expires-after 1)])]
-      (write-session as "mykey" {:foo 1})
+    (let [as (aging-memory-store :events [(event/expires-after 1)])
+          cookie (write-session as "invalid-key" {:a 1})
+          id (:id (verify-and-decrypt-cookie cookie))]
       (. Thread (sleep 1500))
-      (is (= (read-session as "mykey") {})))))
+      (is (= (read-session as cookie) {})))))
 
 (deftest session-expiry-by-sweep
   (testing "Test session expiry sweep."
     (let [as (aging-memory-store
                :events      [(event/expires-after 1)]
                :sweep-every 5
-               :sweep-delay 1000)]
-      (write-session as "mykey" {:foo 1})
+               :sweep-delay 1000)
+          cookie (write-session as "invalid-key" {:a 1})
+          id (:id (verify-and-decrypt-cookie cookie))]
       (. Thread (sleep 1500))
       ; key should still exist, even though it's expired
-      (is (not (nil? (read-timestamp as "mykey"))))
+      (is (not (nil? (read-timestamp as id))))
 
       ; key should exist for three more writes
       (write-session as "other-key" {:foo 1})
-      (is (not (nil? (read-timestamp as "mykey"))))
+      (is (not (nil? (read-timestamp as id))))
       (write-session as "other-key" {:foo 1})
-      (is (not (nil? (read-timestamp as "mykey"))))
+      (is (not (nil? (read-timestamp as id))))
       (write-session as "other-key" {:foo 1})
-      (is (not (nil? (read-timestamp as "mykey"))))
+      (is (not (nil? (read-timestamp as id))))
 
       ; on the fifth write and after 30s, key should not exist
       (write-session as "other-key" {:foo 1})
       (. Thread (sleep 2000))
-      (is (nil? (read-timestamp as "mykey"))))))
+      (is (nil? (read-timestamp as id))))))
 
 (deftest refresh-on-read-nonexistant-key-then-sweep
   (testing "Test an empty session read (with refresh-on-read enabled) then check that the expiry sweep still works"

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -2,7 +2,8 @@
   (:require
     [clojure.test :refer :all]
     [ring.middleware.session.store :refer :all]
-    [aging-session.memory :refer :all]))
+    [aging-session.memory :refer :all]
+    [aging-session.crypto :refer :all]))
 
 (deftest basic-read-empty
   (let [as (aging-memory-store)
@@ -75,7 +76,7 @@
     (let [data {:some :data}
           key (first (get-crypto-keys))
           [iv enc-data] (encrypt key data)]
-      (is (= data (decrypt iv key enc-data)))))
+      (is (= data (decrypt iv enc-data key)))))
   (testing "cookie roundtrip"
     (let [id 1234567]
       (is (= id (:id (verify-and-decrypt-cookie (encrypt-and-hmac-cookie id))))))))

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -9,13 +9,7 @@
   (let [as (aging-memory-store)
         cookie (write-session as nil {:some :thing})]
     (testing "Invalid session is empty."
-      (is (= (read-session as "invalid-cookie") {})))
-    (testing "Session with corrupt IV is empty"
-      (is (= (read-session as (str "badpre" (subs cookie 6))) {})))
-    (testing "Session with corrupt MAC is empty"
-      (is (= (read-session as (str (subs cookie 0 (- (count cookie) 6)) "badsuf")) {})))
-    (testing "Session with corrupt payload is empty"
-      (is (= (read-session as (str (subs cookie 0 40) "badpay" (subs cookie 46))) {})))))
+      (is (= (read-session as "invalid-cookie") {})))))
 
 (deftest basic-write
   (testing "Test session writes and reads."

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer :all]
     [ring.middleware.session.store :refer :all]
     [aging-session.memory :refer :all]
-    [aging-session.crypto :refer :all]))
+    [aging-session.cookie :refer :all]))
 
 (deftest basic-read-empty
   (let [as (aging-memory-store)

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -2,8 +2,8 @@
   (:require
     [clojure.test :refer :all]
     [ring.middleware.session.store :refer :all]
-    [aging-session.memory :refer :all]
-    [aging-session.cookie :refer :all]))
+    [aging-session.cookie :refer :all]
+    [aging-session.memory :refer :all]))
 
 (deftest basic-read-empty
   (let [as (aging-memory-store)
@@ -65,18 +65,3 @@
         (is (= (read-session as cookie) {:a 1}))
         (is (not (= ts1 (read-timestamp as id))))
         (is (= (read-session as cookie) {:a 1}))))))
-
-(deftest crypto-basic-functionality
-  (testing "can create keys"
-    (is (= 2 (count (get-crypto-keys)))))
-  (testing "key creation/retrieval is atomic"             ; this isn't proof, just a best-effort check
-    (is (= 1 (count (into #{} (doall (pmap #(do %& (map base64-encode (get-crypto-keys)))
-                                           (range 100))))))))
-  (testing "encryption roundtrip"
-    (let [data {:some :data}
-          key (first (get-crypto-keys))
-          [iv enc-data] (encrypt key data)]
-      (is (= data (decrypt iv enc-data key)))))
-  (testing "cookie roundtrip"
-    (let [id 1234567]
-      (is (= id (get-id (bake-cookie id)))))))

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -7,7 +7,7 @@
 
 (deftest basic-read-empty
   (let [as (aging-memory-store)
-        cookie (write-session as "invalid-key" {:some :thing})]
+        cookie (write-session as nil {:some :thing})]
     (testing "Invalid session is empty."
       (is (= (read-session as "invalid-cookie") {})))
     (testing "Session with corrupt IV is empty"
@@ -20,7 +20,7 @@
 (deftest basic-write
   (testing "Test session writes and reads."
     (let [as (aging-memory-store)
-          cookie (write-session as "invalid-key" {:a 1})]
+          cookie (write-session as nil {:a 1})]
       (is (= (read-session as cookie) {:a 1}))
       (write-session as cookie {:a 2})
       (is (= (read-session as cookie) {:a 2})))))
@@ -28,7 +28,7 @@
 (deftest basic-delete
   (testing "Test session delete."
     (let [as (aging-memory-store)
-          cookie (write-session as "invalid-key" {:a 1})]
+          cookie (write-session as nil {:a 1})]
       (is (= 1 (:a (read-session as cookie))))
       (delete-session as (get-id cookie))
       (is (= (read-session as cookie) {})))))
@@ -36,7 +36,7 @@
 (deftest timestamp-on-creation
   (testing "Test the behaviour where each entry's timestamp is set only on session creation."
     (let [as (aging-memory-store)
-          cookie (write-session as "invalid-key" {:a 1})
+          cookie (write-session as nil {:a 1})
           id (get-id cookie)]
       (let [ts1 (read-timestamp as id)]
         (is (integer? ts1))
@@ -47,7 +47,7 @@
 (deftest timestamp-on-write
   (testing "Test the behaviour where each entry's timestamp is refreshed on write."
     (let [as (aging-memory-store :refresh-on-write true)
-          cookie (write-session as "invalid-key" {:a 1})
+          cookie (write-session as nil {:a 1})
           id (get-id cookie)]
       (let [ts1 (read-timestamp as id)]
         (. Thread (sleep 10))
@@ -58,7 +58,7 @@
 (deftest timestamp-on-read
   (testing "Test the behaviour where each entry's timestamp is refreshed on read."
     (let [as (aging-memory-store :refresh-on-read true)
-          cookie (write-session as "invalid-key" {:a 1})
+          cookie (write-session as nil {:a 1})
           id (get-id cookie)]
       (let [ts1 (read-timestamp as id)]
         (. Thread (sleep 10))

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -5,51 +5,67 @@
     [aging-session.memory :refer :all]))
 
 (deftest basic-read-empty
-  (testing "Test session reads."
-    (let [as (aging-memory-store)]
-      (is (= (read-session as "mykey") {})))))
+  (let [as (aging-memory-store)
+        cookie (write-session as "invalid-key" {:some :thing})]
+    (testing "Invalid session is empty."
+      (is (= (read-session as "invalid-cookie") {})))
+    (testing "Session with corrupt IV is empty"
+      (is (= (read-session as (str "badpre" (subs cookie 6))) {})))
+    (testing "Session with corrupt MAC is empty"
+      )))
 
 (deftest basic-write
   (testing "Test session writes and reads."
-    (let [as (aging-memory-store)]
-      (write-session as "mykey" {:a 1})
-      (is (= (read-session as "mykey") {:a 1}))
-      (write-session as "mykey" {:a 2})
-      (is (= (read-session as "mykey") {:a 2})))))
+    (let [as (aging-memory-store)
+          cookie (write-session as "invalid-key" {:a 1})]
+      (is (= (read-session as cookie) {:a 1}))
+      (write-session as cookie {:a 2})
+      (is (= (read-session as cookie) {:a 2})))))
 
 (deftest basic-delete
   (testing "Test session delete."
-    (let [as (aging-memory-store)]
-      (write-session as "mykey" {:a 1})
-      (delete-session as "mykey")
-      (is (= (read-session as "mykey") {})))))
+    (let [as (aging-memory-store)
+          cookie (write-session as "invalid-key" {:a 1})]
+      (is (= 1 (:a (read-session as cookie))))
+      (delete-session as (:id (verify-and-decrypt-cookie cookie)))
+      (is (= (read-session as cookie) {})))))
 
 (deftest timestamp-on-creation
   (testing "Test the behaviour where each entry's timestamp is set only on session creation."
-    (let [as (aging-memory-store)]
-      (write-session as "mykey" {:foo 1})
-      (let [ts1 (read-timestamp as "mykey")]
+    (let [as (aging-memory-store)
+          cookie (write-session as "invalid-key" {:a 1})
+          id (:id (verify-and-decrypt-cookie cookie))]
+      (let [ts1 (read-timestamp as id)]
         (is (integer? ts1))
-        (write-session as "mykey" {:foo 2})
-        (is (= ts1 (read-timestamp as "mykey")))
-        (is (= (read-session as "mykey") {:foo 2}))))))
+        (write-session as cookie {:foo 2})
+        (is (= ts1 (read-timestamp as id)))
+        (is (= (read-session as cookie) {:foo 2}))))))
 
 (deftest timestamp-on-write
   (testing "Test the behaviour where each entry's timestamp is refreshed on write."
-    (let [as (aging-memory-store :refresh-on-write true)]
-      (write-session as "mykey" {:foo 1})
-      (let [ts1 (read-timestamp as "mykey")]
+    (let [as (aging-memory-store :refresh-on-write true)
+          cookie (write-session as "invalid-key" {:a 1})
+          id (:id (verify-and-decrypt-cookie cookie))]
+      (let [ts1 (read-timestamp as id)]
         (. Thread (sleep 10))
-        (write-session as "mykey" {:foo 2})
-        (is (not (= ts1 (read-timestamp as "mykey"))))
-        (is (= (read-session as "mykey") {:foo 2}))))))
+        (write-session as cookie {:foo 2})
+        (is (not (= ts1 (read-timestamp as id))))
+        (is (= (read-session as cookie) {:foo 2}))))))
 
 (deftest timestamp-on-read
   (testing "Test the behaviour where each entry's timestamp is refreshed on read."
-    (let [as (aging-memory-store :refresh-on-read true)]
-      (write-session as "mykey" {:foo 1})
-      (let [ts1 (read-timestamp as "mykey")]
+    (let [as (aging-memory-store :refresh-on-read true)
+          cookie (write-session as "invalid-key" {:a 1})
+          id (:id (verify-and-decrypt-cookie cookie))]
+      (let [ts1 (read-timestamp as id)]
         (. Thread (sleep 10))
-        (is (= (read-session as "mykey") {:foo 1}))
-        (is (not (= ts1 (read-timestamp as "mykey"))))
-        (is (= (read-session as "mykey") {:foo 1}))))))
+        (is (= (read-session as cookie) {:a 1}))
+        (is (not (= ts1 (read-timestamp as id))))
+        (is (= (read-session as cookie) {:a 1}))))))
+
+(deftest crypto-basic-functionality
+  (testing "can create keys"
+    (is (= 2 (count (get-crypto-keys)))))
+  (testing "key creation/retrieval is atomic"             ; this isn't proof, just a best-effort check
+    (is (= 1 (count (into #{} (doall (pmap #(do %& (map base64-encode (get-crypto-keys)))
+                                           (range 100)))))))))

--- a/test/aging_session/memory_test.clj
+++ b/test/aging_session/memory_test.clj
@@ -30,14 +30,14 @@
     (let [as (aging-memory-store)
           cookie (write-session as "invalid-key" {:a 1})]
       (is (= 1 (:a (read-session as cookie))))
-      (delete-session as (:id (verify-and-decrypt-cookie cookie)))
+      (delete-session as (get-id cookie))
       (is (= (read-session as cookie) {})))))
 
 (deftest timestamp-on-creation
   (testing "Test the behaviour where each entry's timestamp is set only on session creation."
     (let [as (aging-memory-store)
           cookie (write-session as "invalid-key" {:a 1})
-          id (:id (verify-and-decrypt-cookie cookie))]
+          id (get-id cookie)]
       (let [ts1 (read-timestamp as id)]
         (is (integer? ts1))
         (write-session as cookie {:foo 2})
@@ -48,7 +48,7 @@
   (testing "Test the behaviour where each entry's timestamp is refreshed on write."
     (let [as (aging-memory-store :refresh-on-write true)
           cookie (write-session as "invalid-key" {:a 1})
-          id (:id (verify-and-decrypt-cookie cookie))]
+          id (get-id cookie)]
       (let [ts1 (read-timestamp as id)]
         (. Thread (sleep 10))
         (write-session as cookie {:foo 2})
@@ -59,7 +59,7 @@
   (testing "Test the behaviour where each entry's timestamp is refreshed on read."
     (let [as (aging-memory-store :refresh-on-read true)
           cookie (write-session as "invalid-key" {:a 1})
-          id (:id (verify-and-decrypt-cookie cookie))]
+          id (get-id cookie)]
       (let [ts1 (read-timestamp as id)]
         (. Thread (sleep 10))
         (is (= (read-session as cookie) {:a 1}))
@@ -79,4 +79,4 @@
       (is (= data (decrypt iv enc-data key)))))
   (testing "cookie roundtrip"
     (let [id 1234567]
-      (is (= id (:id (verify-and-decrypt-cookie (encrypt-and-hmac-cookie id))))))))
+      (is (= id (get-id (bake-cookie id)))))))


### PR DESCRIPTION
_This addresses:_
see internal PR

_By doing:_
New cookies are based on a counter
The counter is only reset when the session-store is reset, thus it is impossible to have session collision even in theory.
Security of the cookie is reliant on the SHA512-based HMAC
Cookie values are further obscured from the user with AES256 in CBC mode
Keys are randomly generated every time

_Major changes:_
Cookies now expire after 72hrs **NO MATTER WHAT**.
If someone manages to keep a session active the entire time then one of the following is true:

-  A poor human is being overworked to death - we should terminate the session out of mercy
-  Something failed with activity detection - we should terminate the session out of safety
-  People are hot-seating a computer or botting - we should terminate the session out of spite

The cookies are now also significantly longer - although this shouldn't pose an issue, as it is well within the standard limits